### PR TITLE
chore: add ts-nocheck to the top of tsx files

### DIFF
--- a/src/lib/Behaviors/FillHandleBehavior.tsx
+++ b/src/lib/Behaviors/FillHandleBehavior.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from "react";
 import {
   Location,

--- a/src/lib/Behaviors/ResizeColumnBehavior.tsx
+++ b/src/lib/Behaviors/ResizeColumnBehavior.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from "react";
 import {
   Direction,

--- a/src/lib/CellTemplates/CheckboxCellTemplate.tsx
+++ b/src/lib/CellTemplates/CheckboxCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/ChevronCellTemplate.tsx
+++ b/src/lib/CellTemplates/ChevronCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/DateCellTemplate.tsx
+++ b/src/lib/CellTemplates/DateCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/DropdownCellTemplate.tsx
+++ b/src/lib/CellTemplates/DropdownCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/EmailCellTemplate.tsx
+++ b/src/lib/CellTemplates/EmailCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/HeaderCellTemplate.tsx
+++ b/src/lib/CellTemplates/HeaderCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/NumberCellTemplate.tsx
+++ b/src/lib/CellTemplates/NumberCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/TextCellTemplate.tsx
+++ b/src/lib/CellTemplates/TextCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/CellTemplates/TimeCellTemplate.tsx
+++ b/src/lib/CellTemplates/TimeCellTemplate.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 
 // NOTE: all modules imported below may be imported from '@silevis/reactgrid'

--- a/src/lib/Components/CellEditor.tsx
+++ b/src/lib/Components/CellEditor.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { getReactGridOffsets, getStickyOffset } from '../Functions/elementSizeHelpers';
 import { getScrollOfScrollableElement, getTopScrollableElement } from '../Functions/scrollHelpers';

--- a/src/lib/Components/CellFocus.tsx
+++ b/src/lib/Components/CellFocus.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { translateLocationIdxToLookupKey } from '../Model/CellMatrix';
 import { Location } from '../Model/InternalModel';

--- a/src/lib/Components/CellRenderer.tsx
+++ b/src/lib/Components/CellRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { areLocationsEqual } from '../Functions/areLocationsEqual';
 import { noBorder } from '../Functions/excludeObjectProperties';

--- a/src/lib/Components/ContextMenu.tsx
+++ b/src/lib/Components/ContextMenu.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { State } from "../Model/State";
 import {

--- a/src/lib/Components/ErrorBoundary.tsx
+++ b/src/lib/Components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { Component, ErrorInfo } from 'react';
 
 interface ErrorBoundaryState {

--- a/src/lib/Components/FillHandle.tsx
+++ b/src/lib/Components/FillHandle.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { useRef, useLayoutEffect, useState } from "react";
 import { Location } from "../../core";
 import { State } from "../Model/State";

--- a/src/lib/Components/FillHandleRangeSelection.tsx
+++ b/src/lib/Components/FillHandleRangeSelection.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { PaneContentChild } from '../Model/InternalModel';
 

--- a/src/lib/Components/FillHandleRenderer.tsx
+++ b/src/lib/Components/FillHandleRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { PaneContentChild, Range } from "../../core";
 import { CellSelectionBehavior } from "../Behaviors/CellSelectionBehavior";

--- a/src/lib/Components/GridRenderer.tsx
+++ b/src/lib/Components/GridRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { GridRendererProps } from '../Model/InternalModel';
 import { HiddenElement } from './HiddenElement';

--- a/src/lib/Components/HiddenElement.tsx
+++ b/src/lib/Components/HiddenElement.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { useReactGridState } from "./StateProvider";
 interface HiddenElementProps {

--- a/src/lib/Components/LegacyBrowserGridRenderer.tsx
+++ b/src/lib/Components/LegacyBrowserGridRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { i18n } from "../Functions/i18n";
 import { GridRendererProps } from "../Model/InternalModel";

--- a/src/lib/Components/Line.tsx
+++ b/src/lib/Components/Line.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { useReactGridState } from "./StateProvider";
 

--- a/src/lib/Components/Pane.tsx
+++ b/src/lib/Components/Pane.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { Range } from '../Model/Range';
 import { State } from '../Model/State';

--- a/src/lib/Components/PaneShadow.tsx
+++ b/src/lib/Components/PaneShadow.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { isBrowserFirefox } from '../Functions/firefox';
 

--- a/src/lib/Components/PanesRenderer.tsx
+++ b/src/lib/Components/PanesRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import {
   Pane,

--- a/src/lib/Components/PartialArea.tsx
+++ b/src/lib/Components/PartialArea.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { Range } from "../../core";
 

--- a/src/lib/Components/ReactGrid.tsx
+++ b/src/lib/Components/ReactGrid.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { CellRenderer, ReactGridProps } from "../../core";
 import {

--- a/src/lib/Components/ResizeHandle.tsx
+++ b/src/lib/Components/ResizeHandle.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 
 export const ResizeHandle: React.FC = () => {

--- a/src/lib/Components/ResizeHint.tsx
+++ b/src/lib/Components/ResizeHint.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 
 interface HintProps {

--- a/src/lib/Components/RowRenderer.tsx
+++ b/src/lib/Components/RowRenderer.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from 'react';
 import { translateLocationIdxToLookupKey } from '../Model/CellMatrix';
 import { GridRow, GridColumn, Borders, Location } from '../Model/InternalModel';

--- a/src/lib/Components/SelectedRanges.tsx
+++ b/src/lib/Components/SelectedRanges.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as React from "react";
 import { PaneContentChild, Range } from "../../core";
 import { PartialArea } from "./PartialArea";

--- a/src/lib/Components/Shadow.tsx
+++ b/src/lib/Components/Shadow.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from "react";
 import { useReactGridState } from "./StateProvider";
 

--- a/src/lib/Components/StateProvider.tsx
+++ b/src/lib/Components/StateProvider.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React, { createContext, FC } from "react";
 import { State } from "../Model/State";
 


### PR DESCRIPTION
## Background

Because we use a fork of reactgrid and install it directly without building and publishing, we import TypeScript files. This causes our TSC checks to also check reactgrid files, where they fail checks (note: the checks fail both with the reactgrid tsconfig and the stack tsconfig, but the latter is the relevant one). A simple, albeit kludgy bandaid for this is to add `// @ts-nocheck` to the top of the files so TSC succeeds.

This will enable us to re-enable TypeScript checks in Stack (i.e. https://github.com/AngelList-Stack/stack/pull/7991)

## This PR

Adds `// @ts-nocheck` to the top of the `*.tsx` files, which are the troublesome ones for us.